### PR TITLE
play tutorial from remote youtube videos

### DIFF
--- a/BreadWallet/BRTutorial.h
+++ b/BreadWallet/BRTutorial.h
@@ -1,0 +1,16 @@
+//
+//  BRTutorial.h
+//  LoafWallet
+//
+//  Created by Sun Peng on 16/7/3.
+//  Copyright © 2016年 Aaron Voisine. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface BRTutorial : NSObject
+
+- (instancetype)initWithViewController:(UIViewController *)vc;
+- (void)playWithYoutubeVideoID:(NSString *)videoID;
+
+@end

--- a/BreadWallet/BRTutorial.m
+++ b/BreadWallet/BRTutorial.m
@@ -1,0 +1,110 @@
+//
+//  BRTutorial.m
+//  LoafWallet
+//
+//  Created by Sun Peng on 16/7/3.
+//  Copyright © 2016年 Aaron Voisine. All rights reserved.
+//
+
+#import "BRTutorial.h"
+
+#define WEBVIEW_TAG 9999
+#define ASPECT_RATIO (1440.0/1960)
+
+@interface BRTutorial ()
+
+@property (nonatomic, weak) UIViewController *containerVC;
+@property (nonatomic, strong) UIWebView *playerView;
+
+@end
+
+@implementation BRTutorial
+
+- (instancetype)initWithViewController:(UIViewController *)vc {
+    if (self = [super init]) {
+        self.containerVC = vc;
+    }
+
+    return self;
+}
+
+- (void)playWithYoutubeVideoID:(NSString *)videoID {
+    [self removePlayerView];
+    self.playerView = [self playerViewWithVideoID:videoID];
+    [self prepareExitButton];
+}
+
+#pragma mark - Helper methods
+- (NSString *)youtubeUrlWithVideoID:(NSString *)videoID {
+    return [NSString stringWithFormat:@"https://www.youtube.com/watch?v=%@", videoID];
+}
+
+- (NSString *)videoPlayerHTML:(NSString *)videoID size:(CGSize)size {
+    NSString *embedHTML = @"\
+    <html><head>\
+    <style type=\"text/css\">\
+    body {\
+    background-color: black;\
+    color: white;\
+    text-align: center;\
+    }\
+    </style>\
+    </head><body style=\"margin:0\">\
+    <embed id=\"yt\" src=\"%@\" type=\"application/x-shockwave-flash\" \
+    width=\"%0.0f\" height=\"%0.0f\"></embed>\
+    </body></html>";
+
+    NSString *html = [NSString stringWithFormat:embedHTML,
+                      [self youtubeUrlWithVideoID:videoID],
+                      size.width,
+                      size.height];
+    return html;
+}
+
+- (UIWebView *)playerViewWithVideoID:(NSString *)videoID {
+    UIView *containerView = self.containerVC.view;
+
+    CGFloat targetWidth, targetHeight;
+    if (containerView.frame.size.width > containerView.frame.size.height) {
+        targetHeight = containerView.frame.size.height;
+        targetWidth = targetHeight * ASPECT_RATIO;
+    } else {
+        targetWidth = containerView.frame.size.width;
+        targetHeight = targetWidth / ASPECT_RATIO;
+    }
+
+    CGRect frame = CGRectMake((containerView.frame.size.width - targetWidth) * 0.5,
+                              (containerView.frame.size.height - targetHeight) * 0.5,
+                              targetWidth,
+                              targetHeight);
+    UIWebView *webView = [[UIWebView alloc] initWithFrame:frame];
+    [webView loadHTMLString:[self videoPlayerHTML:videoID size:CGSizeMake(targetWidth, targetHeight)] baseURL:nil];
+    [containerView addSubview:webView];
+    webView.frame = frame;
+    return webView;
+}
+
+- (void)removePlayerView {
+    [self.playerView removeFromSuperview];
+}
+
+- (void)prepareExitButton
+{
+    UIButton *cancelButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
+    [cancelButton addTarget:self action:@selector(handleExit) forControlEvents:UIControlEventTouchUpInside];
+    [cancelButton setFrame:CGRectMake(0, self.containerVC.topLayoutGuide.length, 64, 64)];
+    [cancelButton setTitle:@"X" forState:UIControlStateNormal];
+    [cancelButton setTag:WEBVIEW_TAG];
+
+    [self.containerVC.view addSubview:cancelButton];
+}
+
+- (void)handleExit
+{
+    UIView * subview = [self.containerVC.view viewWithTag:WEBVIEW_TAG];
+    [subview removeFromSuperview];
+
+    [self removePlayerView];
+}
+
+@end

--- a/LoafWallet.xcodeproj/project.pbxproj
+++ b/LoafWallet.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		BAC7B6BE1BD9C29900165B84 /* BRPhoneWCSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BAC7B6BD1BD9C29900165B84 /* BRPhoneWCSessionManager.m */; };
 		BAE12BF21B2DEE7F00895CC5 /* TodayExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = BAE12BE51B2DEE7F00895CC5 /* TodayExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		BAE12C061B2DEEF700895CC5 /* BRTodayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BAE12C051B2DEEF700895CC5 /* BRTodayViewController.m */; };
+		DF4663391D294085003F087A /* BRTutorial.m in Sources */ = {isa = PBXBuildFile; fileRef = DF4663381D294085003F087A /* BRTutorial.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -501,6 +502,8 @@
 		BAE12BEA1B2DEE7F00895CC5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BAE12C041B2DEEF700895CC5 /* BRTodayViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BRTodayViewController.h; sourceTree = "<group>"; };
 		BAE12C051B2DEEF700895CC5 /* BRTodayViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BRTodayViewController.m; sourceTree = "<group>"; };
+		DF4663371D294085003F087A /* BRTutorial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BRTutorial.h; sourceTree = "<group>"; };
+		DF4663381D294085003F087A /* BRTutorial.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BRTutorial.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -861,6 +864,7 @@
 				BAC7B6BF1BD9C2B500165B84 /* AppleWatch */,
 				752E289C19234A4700DB5A3C /* Models */,
 				752E289B19234A3F00DB5A3C /* Views */,
+				DF4663361D29406C003F087A /* Utils */,
 				75BA5D02192296010040304C /* Controllers */,
 				752E28B019234B0500DB5A3C /* Categories */,
 				75D5F3D0191EC270004AB296 /* BRAppDelegate.h */,
@@ -986,6 +990,15 @@
 				BAE12BEA1B2DEE7F00895CC5 /* Info.plist */,
 			);
 			path = TodayExtension;
+			sourceTree = "<group>";
+		};
+		DF4663361D29406C003F087A /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				DF4663371D294085003F087A /* BRTutorial.h */,
+				DF4663381D294085003F087A /* BRTutorial.m */,
+			);
+			name = Utils;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1301,6 +1314,7 @@
 				752E28AF19234AE300DB5A3C /* BRTxOutputEntity.m in Sources */,
 				84F046E71D1009080035D658 /* BRNavigationItem.m in Sources */,
 				22DE8CF11D02407F007F07F3 /* BRWalletConstants.m in Sources */,
+				DF4663391D294085003F087A /* BRTutorial.m in Sources */,
 				BAA4843C1B3EFFAF0075C749 /* UIImage+Utils.m in Sources */,
 				1B49E3E31CFBC32800B64632 /* BRGenerateViewController.m in Sources */,
 				2292799F1C695D2800C98E78 /* BRTar.swift in Sources */,


### PR DESCRIPTION
There are 2 ways to play tutorial video, first is to play a remote youtube video, second is to play the video locally.

This PR is focused on play remote video from youtube.

The pros for this method is:
- you can update video materials for a single version of app without republishing the app

The cons for this method is:
- due to youtube service terms, the video can only be played in a embedded `UIWebView`, which needs user to click one more time to play the video
- needs different youtube id for different app version
- can't show the tutorial offline
- can't show the tutorial to users in some areas where youtube is not avaliable

Well, I personally prefer not to use this method. 

Anyway, I've implemented a helper class `BRTutorial` with a single `playWithYoutubeVideoID:` method. To use it, first import and define a property like this:

    #import "BRTutorial.h"
    @property (strong, nonatomic) BRTutorial *tutorial;

Then, in `viewDidLoad` method in the view controller where you want to play tutorial, init a instance: 

    // viewDidLoad in VC
    self.tutorial = [[BRTutorial alloc] initWithViewController:self];

Finally, call `playTutorial:` with the tutorial video name like this:

    // Play it!
    [self.tutorial playWithYoutubeVideoID:@"uDAxwykobdQ"];